### PR TITLE
Refactored to run hooks and provide APIs for other components

### DIFF
--- a/js/build.js
+++ b/js/build.js
@@ -6,14 +6,19 @@ var Notifications = new Fliplet.Registry.get('fliplet-widget-notifications:1.0:c
 
   // This function will run for each instance found in the page
   Fliplet.Widget.instance('fliplet-widget-notifications-1-0-0', function (data) {
-    // Sample implementation to initialise the widget
+    // Sample implementation to initialize the widget
     notifications = new Notifications(data);
-    notifications.init();
-  });  
+  });
 
   Fliplet.Widget.register('Notifications', function () {
     return notifications;
   });
 
-  Fliplet.Hooks.run('notificationsReady');
+  Fliplet.Hooks.run('beforeNotificationsInit')
+    .then(notifications.init)
+    .catch(function (err) {
+      if (err) {
+        console.warn(err);
+      }
+    });
 })();

--- a/js/libs.js
+++ b/js/libs.js
@@ -179,18 +179,19 @@ Fliplet.Registry.set('fliplet-widget-notifications:1.0:core', function (data) {
           Fliplet.Hooks.run('notificationStream', notification);
         });
 
-        // @HACK Timeout to allow custom code to add .add-notification-badge to elements before running addNotificationBadges()
-        setTimeout(function () {
-          // Adding a timeout to allow page JS to modify page DOM
-          addNotificationBadges();
-          broadcastCountUpdates();
+        Fliplet().then(function () {
+          setTimeout(function () {
+            // Adding a timeout to allow page JS to modify page DOM first
+            addNotificationBadges();
+            broadcastCountUpdates();
 
-          if (!storage.updatedAt || options.startCheckingUpdates) {
-            setTimer(0);
-          } else {
-            createUpdateTimer();
-          }
-        }, 200);
+            if (!storage.updatedAt || options.startCheckingUpdates) {
+              setTimer(0);
+            } else {
+              createUpdateTimer();
+            }
+          }, 0);
+        });
       });
   }
 

--- a/js/libs.js
+++ b/js/libs.js
@@ -3,7 +3,7 @@ Fliplet.Registry.set('fliplet-widget-notifications:1.0:core', function (data) {
   var DELAY = 30000;
 
   var appId = Fliplet.Env.get('appId');
-  var storageKey = 'fl_notifications_' + appId;
+  var storageKey = 'flAppNotifications';
   var storage;
   var instance;
   var clearNewCountOnUpdate = false;

--- a/js/libs.js
+++ b/js/libs.js
@@ -28,13 +28,6 @@ Fliplet.Registry.set('fliplet-widget-notifications:1.0:core', function (data) {
     return Fliplet.App.Storage.set(storageKey, storage);
   }
 
-  function clearNewCount() {
-    return saveCounts({
-      updatedAt: storage.updatedAt,
-      newCount: 0
-    });
-  }
-
   function markAsRead(notifications) {
     return instance.markNotificationsAsRead(notifications)
       .then(function (results) {
@@ -207,7 +200,6 @@ Fliplet.Registry.set('fliplet-widget-notifications:1.0:core', function (data) {
     markAsRead: markAsRead,
     markAllAsRead: markAllAsRead,
     isPolling: isPolling,
-    poll: poll,
-    clearNewCount: clearNewCount
+    poll: poll
   };
 });


### PR DESCRIPTION
- `Notifications` component is registered to be accessible via other components.
- `beforeNotificationsInit` hook is run before component initialization to allow other components to set up hooks, observers and take over the initialization if necessary.
- Methods
   - `init` Component initialization. Starts scheduled checks for updates and polling and sets up hooks.
   - `checkForUpdates` Checks for unread counts since provided `ts` and polls for new notifications if counts have changed.
   - `markAsRead` Mark an array of notifications as read.
   - `markAllAsRead` Mark all notifications as read.
   - `isPolling` Returns `true` if the notification instance is currently polling for notifications.
   - `poll` Polls for new notifications.
