### PR TITLE
Check for new notifications when pages have loaded

### DIFF
--- a/js/libs.js
+++ b/js/libs.js
@@ -73,8 +73,14 @@ Fliplet.Registry.set('fliplet-widget-notifications:1.0:core', function (data) {
       });
   }
 
-  function addNotificationBadges() {
-    if (isNaN(storage.newCount) || storage.newCount <= 0) {
+  function addNotificationBadges(options) {
+    options = options || {};
+
+    var count = options.count || storage.newCount;
+
+    count = parseInt(count, 10);
+
+    if (isNaN(count) || count <= 0) {
       $('.add-notification-badge')
         .removeClass('has-notification-badge')
         .find('.notification-badge').remove();
@@ -84,7 +90,7 @@ Fliplet.Registry.set('fliplet-widget-notifications:1.0:core', function (data) {
     $('.add-notification-badge')
       .addClass('has-notification-badge')
       .find('.notification-badge').remove().end()
-      .append('<div class="notification-badge">' + storage.newCount + '</div>');
+      .append('<div class="notification-badge">' + count + '</div>');
   }
 
   function broadcastCountUpdates() {
@@ -227,6 +233,7 @@ Fliplet.Registry.set('fliplet-widget-notifications:1.0:core', function (data) {
     markAllAsRead: markAllAsRead,
     isPolling: isPolling,
     poll: poll,
-    getInstance: getInstance
+    getInstance: getInstance,
+    addNotificationBadges: addNotificationBadges
   };
 });

--- a/js/libs.js
+++ b/js/libs.js
@@ -208,6 +208,7 @@ Fliplet.Registry.set('fliplet-widget-notifications:1.0:core', function (data) {
             // Adding a timeout to allow page JS to modify page DOM first
             addNotificationBadges();
             broadcastCountUpdates();
+            checkForUpdatesSinceLastClear();
 
             if (!storage.updatedAt || options.startCheckingUpdates) {
               setTimer(0);

--- a/js/libs.js
+++ b/js/libs.js
@@ -74,6 +74,10 @@ Fliplet.Registry.set('fliplet-widget-notifications:1.0:core', function (data) {
   }
 
   function addNotificationBadges(options) {
+    if (typeof options !== 'undefined' && !_.isObject(options)) {
+      options = { count: options };
+    }
+
     options = options || {};
 
     var count = options.count || storage.newCount;


### PR DESCRIPTION
Ref. https://github.com/Fliplet/fliplet-studio/issues/5727

We previously [disabled autopollng](https://github.com/Fliplet/fliplet-widget-notifications/pull/5) to [reduce the load on our servers](https://github.com/Fliplet/fliplet-studio/issues/5053).

This also ended up removing the check for new updates, hence [preventing the badges from showing up](https://github.com/Fliplet/fliplet-studio/issues/5727).

We're adding that back in so that it checks for updates once when the page loads. This will add load back to our servers, but nowhere near to the same level as it used to be.

A public `addNotificationBadges()` has also been added for testing purposes.