### PR TITLE
Enable offline mode when streaming notifications

### DIFF
--- a/js/libs.js
+++ b/js/libs.js
@@ -211,7 +211,7 @@ Fliplet.Registry.set('fliplet-widget-notifications:1.0:core', function (data) {
 
         instance.stream(function (notification) {
           Fliplet.Hooks.run('notificationStream', notification);
-        });
+        }, { offline: true });
 
         Fliplet().then(function () {
           setTimeout(function () {


### PR DESCRIPTION
Ref. https://github.com/Fliplet/fliplet-studio/issues/4374

Enables offline mode when initializing notification streaming.